### PR TITLE
Enable anonymous ping

### DIFF
--- a/src/plugin-tunnel.ts
+++ b/src/plugin-tunnel.ts
@@ -15,13 +15,13 @@ module.exports = {
   version: '1.0.0',
   manifest: {
     connect: 'duplex',
+    ping: 'sync',
     // The following are not implemented client-side but need to be declared
     // in the manifest in order for muxrpc to allow them to be called remotely:
     announce: 'sync',
     leave: 'sync',
     endpoints: 'source',
     isRoom: 'async',
-    ping: 'sync',
   },
   permissions: {
     anonymous: {allow: ['connect', 'ping']},
@@ -52,6 +52,10 @@ module.exports = {
         } else {
           return ErrorDuplex(`could not connect to ${target}`);
         }
+      },
+
+      ping() {
+        return Date.now()
       },
 
       // Internal method, needed for api-plugin.ts

--- a/src/plugin-tunnel.ts
+++ b/src/plugin-tunnel.ts
@@ -24,7 +24,7 @@ module.exports = {
     ping: 'sync',
   },
   permissions: {
-    anonymous: {allow: ['connect']},
+    anonymous: {allow: ['connect', 'ping']},
   },
   init(ssb: SSB) {
     if (!hasConnInstalled(ssb)) {


### PR DESCRIPTION
After upgrading to ssb-room-client I noticed that ping for direct connections was not working anymore in the browser.  This fixes that.